### PR TITLE
Change matrix_multiply_par_range to matrix_multiply_par_range2d

### DIFF
--- a/es/labs/05-tbb/ej2.tex
+++ b/es/labs/05-tbb/ej2.tex
@@ -171,4 +171,4 @@ ambas dimensiones hasta un cierto nivel de granularidad. Cuando un rango no se
 divide más se pasa éste a la lambda.
 
 Utiliza este tipo de llamada para modificar la función
-\cppid{matrix\_multiply\_par\_range()} y mide la aceleración conseguida.
+\cppid{matrix\_multiply\_par\_range2d()} y mide la aceleración conseguida.


### PR DESCRIPTION
- En la página 10 del enunciado pone "modificar la función matrix_multiply_par_range()", pero debería ser matrix_multiply_par_range2d(). 
- Revisar versión en inglés.