### PR TITLE
[English version] Change matrix_multiply_par_range to matrix_multiply_par_range2d

### DIFF
--- a/en/labs/05-tbb/ej2.tex
+++ b/en/labs/05-tbb/ej2.tex
@@ -171,4 +171,4 @@ both dimensions down to a certain level of granularity. When a range is no longe
 divided it is passed to the lambda.
 
 Use this type of call to modify the
-\cppid{matrix\_multiply\_par\_range()} function and measure the achieved speedup.
+\cppid{matrix\_multiply\_par\_range2d()} function and measure the achieved speedup.


### PR DESCRIPTION
Corrige la errata #89 en el documento de inglés.